### PR TITLE
Refactor auth

### DIFF
--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -3,11 +3,23 @@ package api
 import "testing"
 
 func TestGetAuth(t *testing.T) {
-	if len(AuthInfo) != 0 {
-		t.Errorf("AuthInfo should be empty, it is %d", len(AuthInfo))
+	_, okDocker := AuthInfo.Load("dockerhub")
+	_, okQuay := AuthInfo.Load("quay")
+
+	if okDocker != false {
+		t.Errorf("AuthInfo should not be loaded, we got %t", okDocker)
 	}
+	if okQuay != false {
+		t.Errorf("AuthInfo should not be loaded, we got %t", okQuay)
+	}
+
 	GetAuth()
-	if len(AuthInfo) != 2 {
-		t.Errorf("AuthInfo should be len 2, it is %d", len(AuthInfo))
+	_, okDocker = AuthInfo.Load("dockerhub")
+	_, okQuay = AuthInfo.Load("quay")
+	if okDocker != true {
+		t.Errorf("AuthInfo should be loaded, we got %t", okDocker)
+	}
+	if okQuay != true {
+		t.Errorf("AuthInfo should be loaded, we got %t", okQuay)
 	}
 }

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -1,22 +1,13 @@
 package api
 
-// import "testing"
+import "testing"
 
-// func TestGetRegistryAuth(t *testing.T) {
-// 	tt := []struct {
-// 		input       string
-// 		expected    string
-// 		expectedErr error
-// 	}{
-// 		{"ImageName", "RegistryAuth", nil},
-// 	}
-// 	for _, v := range tt {
-// 		actual, err := GetRegistryAuth(v.input)
-// 		if err != nil {
-// 			t.Errorf("\nran GetRegistryAuth(%#+v) \ngot %s \nwanted %#+v", v.input, err, v.expected)
-// 		}
-// 		if actual != v.expected {
-// 			t.Errorf("\nran GetRegistryAuth(%#+v) \ngot %#+v \nwanted %#+v", v.input, actual, v.expected)
-// 		}
-// 	}
-// }
+func TestGetAuth(t *testing.T) {
+	if len(AuthInfo) != 0 {
+		t.Errorf("AuthInfo should be empty, it is %d", len(AuthInfo))
+	}
+	GetAuth()
+	if len(AuthInfo) != 2 {
+		t.Errorf("AuthInfo should be len 2, it is %d", len(AuthInfo))
+	}
+}

--- a/api/container.go
+++ b/api/container.go
@@ -49,7 +49,7 @@ func CreateContainer(ctx context.Context, s ServiceConfig, networkName, formatte
 	//2.4 create restart policy
 	restartPolicy := container.RestartPolicy{}
 	if s.Restart != "" {
-		// AuthInfou cannot set MaximumRetryCount for the following restart policies;
+		// You cannot set MaximumRetryCount for the following restart policies;
 		// always, no, unless-stopped
 		if s.Restart == "on-failure" {
 			restartPolicy = container.RestartPolicy{Name: s.Restart, MaximumRetryCount: 3}

--- a/api/container.go
+++ b/api/container.go
@@ -49,7 +49,7 @@ func CreateContainer(ctx context.Context, s ServiceConfig, networkName, formatte
 	//2.4 create restart policy
 	restartPolicy := container.RestartPolicy{}
 	if s.Restart != "" {
-		// you cannot set MaximumRetryCount for the following restart policies;
+		// AuthInfou cannot set MaximumRetryCount for the following restart policies;
 		// always, no, unless-stopped
 		if s.Restart == "on-failure" {
 			restartPolicy = container.RestartPolicy{Name: s.Restart, MaximumRetryCount: 3}

--- a/api/image.go
+++ b/api/image.go
@@ -16,10 +16,11 @@ import (
 )
 
 func PullDockerImage(ctx context.Context, imageName string, cli MeliAPiClient) error {
-	GetRegistryAuth := AuthInfo["dockerhub"]["RegistryAuth"]
+	result, _ := AuthInfo.Load("dockerhub")
 	if strings.Contains(imageName, "quay") {
-		GetRegistryAuth = AuthInfo["quay"]["RegistryAuth"]
+		result, _ = AuthInfo.Load("quay")
 	}
+	GetRegistryAuth := result.(map[string]string)["RegistryAuth"]
 
 	imagePullResp, err := cli.ImagePull(
 		ctx,
@@ -84,15 +85,14 @@ func BuildDockerImage(ctx context.Context, dockerFile string, cli MeliAPiClient)
 	splitImageName := strings.Split(splitDockerfile[1], "\n")
 	imgFromDockerfile := splitImageName[0]
 
-	registryURL := AuthInfo["dockerhub"]["registryURL"]
-	username := AuthInfo["dockerhub"]["username"]
-	password := AuthInfo["dockerhub"]["password"]
-
+	result, _ := AuthInfo.Load("dockerhub")
 	if strings.Contains(imgFromDockerfile, "quay") {
-		registryURL = AuthInfo["quay"]["registryURL"]
-		username = AuthInfo["quay"]["username"]
-		password = AuthInfo["quay"]["password"]
+		result, _ = AuthInfo.Load("quay")
 	}
+	authInfo := result.(map[string]string)
+	registryURL := authInfo["registryURL"]
+	username := authInfo["username"]
+	password := authInfo["password"]
 
 	AuthConfigs := make(map[string]types.AuthConfig)
 	AuthConfigs[registryURL] = types.AuthConfig{Username: username, Password: password}

--- a/api/image.go
+++ b/api/image.go
@@ -16,10 +16,9 @@ import (
 )
 
 func PullDockerImage(ctx context.Context, imageName string, cli MeliAPiClient) error {
-	GetRegistryAuth, err := GetRegistryAuth(imageName)
-	if err != nil {
-		log.Println(err, " :unable to get registry credentials for image, ", imageName)
-		return err
+	GetRegistryAuth := AuthInfo["dockerhub"]["RegistryAuth"]
+	if strings.Contains(imageName, "quay") {
+		GetRegistryAuth = AuthInfo["quay"]["RegistryAuth"]
 	}
 
 	imagePullResp, err := cli.ImagePull(
@@ -85,10 +84,16 @@ func BuildDockerImage(ctx context.Context, dockerFile string, cli MeliAPiClient)
 	splitImageName := strings.Split(splitDockerfile[1], "\n")
 	imgFromDockerfile := splitImageName[0]
 
-	registryURL, username, password, err := GetAuth(imgFromDockerfile)
-	if err != nil {
-		return "", &popagateError{originalErr: err}
+	registryURL := AuthInfo["dockerhub"]["registryURL"]
+	username := AuthInfo["dockerhub"]["username"]
+	password := AuthInfo["dockerhub"]["password"]
+
+	if strings.Contains(imgFromDockerfile, "quay") {
+		registryURL = AuthInfo["quay"]["registryURL"]
+		username = AuthInfo["quay"]["username"]
+		password = AuthInfo["quay"]["password"]
 	}
+
 	AuthConfigs := make(map[string]types.AuthConfig)
 	AuthConfigs[registryURL] = types.AuthConfig{Username: username, Password: password}
 

--- a/api/image_test.go
+++ b/api/image_test.go
@@ -44,10 +44,6 @@ func TestGetBuildDockerImage(t *testing.T) {
 }
 
 func BenchmarkPullDockerImage(b *testing.B) {
-	// 153,701 ns/op
-	// 150,209 ns/op
-	// 152,565 ns/op
-
 	var ctx = context.Background()
 	cli := &MockDockerClient{}
 	GetAuth()

--- a/api/image_test.go
+++ b/api/image_test.go
@@ -44,6 +44,10 @@ func TestGetBuildDockerImage(t *testing.T) {
 }
 
 func BenchmarkPullDockerImage(b *testing.B) {
+	// 153,701 ns/op
+	// 150,209 ns/op
+	// 152,565 ns/op
+
 	var ctx = context.Background()
 	cli := &MockDockerClient{}
 	for n := 0; n < b.N; n++ {

--- a/api/image_test.go
+++ b/api/image_test.go
@@ -50,6 +50,7 @@ func BenchmarkPullDockerImage(b *testing.B) {
 
 	var ctx = context.Background()
 	cli := &MockDockerClient{}
+	GetAuth()
 	for n := 0; n < b.N; n++ {
 		_ = PullDockerImage(ctx, "busybox", cli)
 	}

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err, " :unable to create/get network")
 	}
-	go GetAuth()
+	go api.GetAuth()
 
 	// Create top level volumes, if any
 	if len(dockerCyaml.Volumes) > 0 {

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err, " :unable to create/get network")
 	}
+	go GetAuth()
 
 	// Create top level volumes, if any
 	if len(dockerCyaml.Volumes) > 0 {

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err, " :unable to create/get network")
 	}
-	go api.GetAuth()
+	api.GetAuth()
 
 	// Create top level volumes, if any
 	if len(dockerCyaml.Volumes) > 0 {


### PR DESCRIPTION
cache auth info instead of hitting disk for every container.

As a result of this change, Pulling docker Images is now about 10 times faster. 
`go test -timeout 3m -race -cover -v -bench=BenchmarkPullDockerImage -run=XXX ./...` 

old: `153,701 ns/op`

new(with normal map): `15,915 ns/op`

newer(with syncMap): 16,228 ns/op,  16,007 ns/op