### PR TITLE
Pretty stdout

### DIFF
--- a/api/container.go
+++ b/api/container.go
@@ -1,10 +1,10 @@
 package api
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -172,7 +172,14 @@ func ContainerLogs(ctx context.Context, cli MeliAPiClient, dc *DockerContainer) 
 				newErr:      fmt.Errorf(" :unable to get container logs %s", dc.ContainerID)}
 		}
 	}
-	io.Copy(dc.LogMedium, containerLogResp)
+
+	scanner := bufio.NewScanner(containerLogResp)
+	for scanner.Scan() {
+		fmt.Fprintln(dc.LogMedium, dc.ServiceName, "::", scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println(" :unable to log output for container", dc.ContainerID, err)
+	}
 
 	containerLogResp.Close()
 	return nil

--- a/api/types.go
+++ b/api/types.go
@@ -109,6 +109,7 @@ func (m *MockDockerClient) ContainerList(ctx context.Context, options types.Cont
 
 type ImageProgress struct {
 	Status         string `json:"status,omitempty"`
+	Stream         string `json:"stream,omitempty"`
 	Progress       string `json:"progress,omitempty"`
 	ProgressDetail string `json:"progressDetail,omitempty"`
 }

--- a/api/types.go
+++ b/api/types.go
@@ -106,3 +106,9 @@ func (m *MockDockerClient) VolumeCreate(ctx context.Context, options volumetypes
 func (m *MockDockerClient) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
 	return []types.Container{types.Container{ID: "myExistingContainerId00912"}}, nil
 }
+
+type ImageProgress struct {
+	Status         string `json:"status,omitempty"`
+	Progress       string `json:"progress,omitempty"`
+	ProgressDetail string `json:"progressDetail,omitempty"`
+}


### PR DESCRIPTION
//new benchmarks:
```bash
BenchmarkGetAuth-32                 	  100000	     15688 ns/op
BenchmarkCreateContainer-32         	  300000	      5346 ns/op
BenchmarkContainerStart-32          	10000000	       197 ns/op
BenchmarkContainerLogs-32           	  100000	     14867 ns/op
BenchmarkFormatLabels-32            	 1000000	      1391 ns/op
BenchmarkFormatPorts-32             	 2000000	       712 ns/op
BenchmarkFormatServiceVolumes-32    	 1000000	      1206 ns/op
BenchmarkFormatImageName-32         	 1000000	      1924 ns/op
BenchmarkPullDockerImage-32         	  100000	     17024 ns/op
BenchmarkBuildDockerImage-32        	  200000	     11427 ns/op
BenchmarkGetNetwork-32              	 5000000	       280 ns/op
BenchmarkConnectNetwork-32          	 3000000	       444 ns/op
BenchmarkCreateDockerVolume-32      	  500000	      3265 ns/op
```
// old benchmarks(ie master branch)
```bash
BenchmarkGetAuth-32                 	  100000	     13401 ns/op
BenchmarkCreateContainer-32         	  200000	      6000 ns/op
BenchmarkContainerStart-32          	10000000	       198 ns/op
BenchmarkContainerLogs-32           	  200000	      6539 ns/op
BenchmarkFormatLabels-32            	 1000000	      1312 ns/op
BenchmarkFormatPorts-32             	 2000000	       798 ns/op
BenchmarkFormatServiceVolumes-32    	 1000000	      1218 ns/op
BenchmarkFormatImageName-32         	 1000000	      1977 ns/op
BenchmarkPullDockerImage-32         	  200000	      7174 ns/op
BenchmarkBuildDockerImage-32        	  200000	     12336 ns/op
BenchmarkGetNetwork-32              	 5000000	       306 ns/op
BenchmarkConnectNetwork-32          	 3000000	       471 ns/op
BenchmarkCreateDockerVolume-32      	  500000	      3487 ns/op
```