### PR TITLE
install.sh: fix typo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ usage() {
 $this: download go binaries for komuw/meli
 
 Usage: $this [-b] bindir [version]
-  -b sets bindir or installation directory, default "/usr/local/bin}"
+  -b sets bindir or installation directory, default "/usr/local/bin"
    [version] is a version number from
    https://github.com/komuw/meli/releases
    If version is missing, then an attempt to find the latest will be found.


### PR DESCRIPTION
altho the script says it's autogenerated, i could not find such fragment from godownloader source. so i assumed it's locally modified.