### PR TITLE
Upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.10 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.6.2+incompatible // indirect
-	github.com/docker/docker v1.13.1
+	github.com/docker/docker v0.0.0-20170601211448-f5ec1e2936dc // v17.03.2-ce
 	github.com/docker/docker-credential-helpers v0.6.1
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.3.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ require (
 	github.com/Microsoft/go-winio v0.4.10 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.6.2+incompatible // indirect
-	github.com/docker/docker v0.0.0-20170601211448-f5ec1e2936dc // v17.03.2-ce
+	// docker v17.03.2-ce
+	github.com/docker/docker v0.0.0-20170601211448-f5ec1e2936dc
 	github.com/docker/docker-credential-helpers v0.6.1
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.6.2+incompatible h1:4FI6af79dfCS/CYb+RRtkSHw3q1L/bnDjG1PcPZtQhM=
 github.com/docker/distribution v2.6.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v1.13.1 h1:5VBhsO6ckUxB0A8CE5LlUJdXzik9cbEbBTQ/ggeml7M=
-github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v0.0.0-20170601211448-f5ec1e2936dc h1:AmviDYdbQqIJukzphvRzpsKbNxSWIxhMFZ3ovTn4bnw=
+github.com/docker/docker v0.0.0-20170601211448-f5ec1e2936dc/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.1 h1:Dq4iIfcM7cNtddhLVWe9h4QDjsi4OER3Z8voPu/I52g=
 github.com/docker/docker-credential-helpers v0.6.1/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=


### PR DESCRIPTION
Thank you for contributing to meli.                    
Every contribution to meli is important to us.                                   

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to meli, and meli agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that meli shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed/added/removed?)
- upgrade docker

## Why(Why did you change/add/remove it?)
- docker no longer uses semantic versioning; it uses a time-based[1] versioning scheme
The latest release on github is now v17.03.2-ce [2]
Although that release(from june 2017) is still very old compared to the version running on my machine;
` docker version`
```bash
Client:
 Version:           18.06.0-ce
 Built:             Wed Jul 18 19:09:54 2018

Server:
 Engine:
  Version:          18.06.0-ce
  Built:            Wed Jul 18 19:07:56 2018
```
so we need to investigate how to download the new clients, since they do not appear to be released on github
The issue for that is; https://github.com/komuw/meli/issues/108

1. https://medium.com/@nagarwal/dockers-new-versioning-scheme-introduced-9bf594a278cf
2. https://github.com/moby/moby/releases/tag/v17.03.2-ce
