### PR TITLE
reset []bytes after getting them from sync.Pool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
                 if [ "$CIRCLE_BRANCH" == "master" ]; then
                     printf "\n $CIRCLE_BRANCH branch, ignoring check for relese notes \n"
                 else
-                    ChangedFiles=`git diff --name-only $CIRCLE_BRANCH origin/master`
+                    ChangedFiles=`git diff --name-only origin/master`
                     case "$ChangedFiles" in
                         *RELEASE_NOTES.*)
                             printf "\n Thanks, your commits include update to release notes. \n";;

--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -8,6 +8,7 @@
 - removed vendor directory and dep files: https://github.com/komuw/meli/pull/107
 - we no longer release meli for 386 arch on github releases.  
   We now ONLY release amd64 for darwin, linux and windows
+- Fixed a bug where buffers from sync.Pool were not reset before use: https://github.com/komuw/meli/pull/119
 
 
 ## v0.1.9.8

--- a/image.go
+++ b/image.go
@@ -116,6 +116,12 @@ var blackHolePool = sync.Pool{
 // this is taken from io.util
 func poolReadFrom(r io.Reader) (n int64, err error) {
 	bufp := blackHolePool.Get().(*[]byte)
+	// reset the buffer since it may contain data from a previous round
+	// see issues/118
+	for i := range *bufp {
+		(*bufp)[i] = 0
+
+	}
 	readSize := 0
 	for {
 		readSize, err = r.Read(*bufp)

--- a/image_test.go
+++ b/image_test.go
@@ -3,6 +3,7 @@ package meli
 import (
 	"context"
 	"io/ioutil"
+	"strings"
 	"testing"
 )
 
@@ -89,5 +90,16 @@ func BenchmarkBuildDockerImage(b *testing.B) {
 	LoadAuth()
 	for n := 0; n < b.N; n++ {
 		_, _ = BuildDockerImage(ctx, cli, dc)
+	}
+}
+
+func BenchmarkPoolReadFrom(b *testing.B) {
+	// go test -run=XXX -bench=BenchmarkPoolReadFrom
+	// BenchmarkPoolReadFrom-4   	30000000	        36.0 ns/op
+	// after fixing issues/118:                         50.1 ns/op
+	r := strings.NewReader("hello")
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, _ = poolReadFrom(r)
 	}
 }


### PR DESCRIPTION
Thank you for contributing to meli.                    
Every contribution to meli is important to us.                                   

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to meli, and meli agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that meli shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed/added/removed?)
- reset the buffer, after getting it from a sync.Pool, since it may contain data from a previous round

## Why(Why did you change/add/remove it?)
- fixes https://github.com/komuw/meli/issues/118
