### PR TITLE
Fix for Dockerfile smell DL3006

### DIFF
--- a/testdata/volumeDockerfile
+++ b/testdata/volumeDockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM busybox:1.36.0-glibc
 
 COPY . /home/
 


### PR DESCRIPTION
Thank you for contributing to meli.                    
Every contribution to meli is important to us.                                   

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to meli, and meli agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that meli shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed/added/removed?)
Version pinning for Dockerfile base image


## Why(Why did you change/add/remove it?)
Hi!
The Dockerfile placed at "testdata/volumeDockerfile" contains the best practice violation [DL3006](https://github.com/hadolint/hadolint/wiki/DL3006) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3006 occurs when the image tag for the base image is missing.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for the given base image. In detail, it selects the most recent image tag which corresponds to the same image digest that currently corresponds to the "latest" tag, used by default when pulling the image from DockerHub if a specific image tag is missing.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance
